### PR TITLE
[squid:S2095] Resources should be closed

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/DumpFields.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/DumpFields.java
@@ -110,11 +110,10 @@ public class DumpFields {
             System.exit(1);
         }
 
-        try {
+        try (FileOutputStream outStream = new FileOutputStream(outFile)) {
             DexBackedDexFile dexFile = DexFileFactory.loadDexFile(dexFileFile, apiLevel, experimental);
             Iterable<String> bootClassPaths = Splitter.on(":").split("core.jar:ext.jar:framework.jar:android.policy.jar:services.jar");
             ClassPath classPath = ClassPath.fromClassPath(bootClassPathDirs, bootClassPaths, dexFile, apiLevel, experimental);
-            FileOutputStream outStream = new FileOutputStream(outFile);
 
             for (ClassDef classDef: dexFile.getClasses()) {
                 ClassProto classProto = (ClassProto) classPath.getClass(classDef);
@@ -127,7 +126,6 @@ public class DumpFields {
                 }
                 outStream.write("\n".getBytes());
             }
-            outStream.close();
         } catch (IOException ex) {
             System.out.println("IOException thrown when trying to open a dex file or write out vtables: " + ex);
         }

--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/DumpVtables.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/DumpVtables.java
@@ -108,11 +108,10 @@ public class DumpVtables {
             System.exit(1);
         }
 
-        try {
+        try (FileOutputStream outStream = new FileOutputStream(outFile)) {
             DexBackedDexFile dexFile = DexFileFactory.loadDexFile(dexFileFile, apiLevel, experimental);
             Iterable<String> bootClassPaths = Splitter.on(":").split("core.jar:ext.jar:framework.jar:android.policy.jar:services.jar");
             ClassPath classPath = ClassPath.fromClassPath(bootClassPathDirs, bootClassPaths, dexFile, apiLevel, experimental);
-            FileOutputStream outStream = new FileOutputStream(outFile);
 
             for (ClassDef classDef: dexFile.getClasses()) {
                 ClassProto classProto = (ClassProto) classPath.getClass(classDef);
@@ -131,7 +130,6 @@ public class DumpVtables {
                 }
                 outStream.write("\n".getBytes());
             }
-            outStream.close();
         } catch (IOException ex) {
             System.out.println("IOException thrown when trying to open a dex file or write out vtables: " + ex);
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2095 - “Resources should be closed”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2095

Please let me know if you have any questions.
Ayman Abdelghany.