### PR TITLE
[squid:S1444] "public static" fields should be constant

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/AnalyzedInstruction.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/AnalyzedInstruction.java
@@ -118,7 +118,7 @@ public class AnalyzedInstruction implements Comparable<AnalyzedInstruction> {
         }
     }
 
-    public static Instruction START_INSTR = new StartInstruction();
+    public static final Instruction START_INSTR = new StartInstruction();
 
     public AnalyzedInstruction(
             @Nonnull MethodAnalyzer methodAnalyzer, @Nonnull Instruction instruction,

--- a/dexlib2/src/main/java/org/jf/dexlib2/util/FieldUtil.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/util/FieldUtil.java
@@ -39,13 +39,13 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public final class FieldUtil {
-    public static Predicate<Field> FIELD_IS_STATIC = new Predicate<Field>() {
+    public static final Predicate<Field> FIELD_IS_STATIC = new Predicate<Field>() {
         @Override public boolean apply(@Nullable Field input) {
             return input!=null && isStatic(input);
         }
     };
 
-    public static Predicate<Field> FIELD_IS_INSTANCE = new Predicate<Field>() {
+    public static final Predicate<Field> FIELD_IS_INSTANCE = new Predicate<Field>() {
         @Override public boolean apply(@Nullable Field input) {
             return input!= null && !isStatic(input);
         }

--- a/dexlib2/src/main/java/org/jf/dexlib2/util/MethodUtil.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/util/MethodUtil.java
@@ -47,13 +47,13 @@ public final class MethodUtil {
     private static int directMask = AccessFlags.STATIC.getValue() | AccessFlags.PRIVATE.getValue() |
             AccessFlags.CONSTRUCTOR.getValue();
 
-    public static Predicate<Method> METHOD_IS_DIRECT = new Predicate<Method>() {
+    public static final Predicate<Method> METHOD_IS_DIRECT = new Predicate<Method>() {
         @Override public boolean apply(@Nullable Method input) {
             return input != null && isDirect(input);
         }
     };
 
-    public static Predicate<Method> METHOD_IS_VIRTUAL = new Predicate<Method>() {
+    public static final Predicate<Method> METHOD_IS_VIRTUAL = new Predicate<Method>() {
         @Override public boolean apply(@Nullable Method input) {
             return input != null && !isDirect(input);
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1444 - “"public static" fields should be constant”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1444

Please let me know if you have any questions.
Ayman Abdelghany.