### PR TITLE
[squid:S2293] The operator ("<>") should be used.

### DIFF
--- a/baksmali/src/main/java/org/jf/baksmali/Adaptors/ClassDefinition.java
+++ b/baksmali/src/main/java/org/jf/baksmali/Adaptors/ClassDefinition.java
@@ -64,7 +64,7 @@ public class ClassDefinition {
 
     @Nonnull
     private HashSet<String> findFieldsSetInStaticConstructor() {
-        HashSet<String> fieldsSetInStaticConstructor = new HashSet<String>();
+        HashSet<String> fieldsSetInStaticConstructor = new HashSet<>();
 
         for (Method method: classDef.getDirectMethods()) {
             if (method.getName().equals("<clinit>")) {
@@ -176,7 +176,7 @@ public class ClassDefinition {
 
     private Set<String> writeStaticFields(IndentingWriter writer) throws IOException {
         boolean wroteHeader = false;
-        Set<String> writtenFields = new HashSet<String>();
+        Set<String> writtenFields = new HashSet<>();
 
         Iterable<? extends Field> staticFields;
         if (classDef instanceof DexBackedClassDef) {
@@ -211,7 +211,7 @@ public class ClassDefinition {
 
     private void writeInstanceFields(IndentingWriter writer, Set<String> staticFields) throws IOException {
         boolean wroteHeader = false;
-        Set<String> writtenFields = new HashSet<String>();
+        Set<String> writtenFields = new HashSet<>();
 
         Iterable<? extends Field> instanceFields;
         if (classDef instanceof DexBackedClassDef) {
@@ -248,7 +248,7 @@ public class ClassDefinition {
 
     private Set<String> writeDirectMethods(IndentingWriter writer) throws IOException {
         boolean wroteHeader = false;
-        Set<String> writtenMethods = new HashSet<String>();
+        Set<String> writtenMethods = new HashSet<>();
 
         Iterable<? extends Method> directMethods;
         if (classDef instanceof DexBackedClassDef) {
@@ -287,7 +287,7 @@ public class ClassDefinition {
 
     private void writeVirtualMethods(IndentingWriter writer, Set<String> directMethods) throws IOException {
         boolean wroteHeader = false;
-        Set<String> writtenMethods = new HashSet<String>();
+        Set<String> writtenMethods = new HashSet<>();
 
         Iterable<? extends Method> virtualMethods;
         if (classDef instanceof DexBackedClassDef) {

--- a/baksmali/src/main/java/org/jf/baksmali/Adaptors/Format/InstructionMethodItemFactory.java
+++ b/baksmali/src/main/java/org/jf/baksmali/Adaptors/Format/InstructionMethodItemFactory.java
@@ -61,7 +61,7 @@ public class InstructionMethodItemFactory {
             case SparseSwitchPayload:
                 return new SparseSwitchMethodItem(methodDef, codeAddress, (SparseSwitchPayload)instruction);
             default:
-                return new InstructionMethodItem<Instruction>(methodDef, codeAddress, instruction);
+                return new InstructionMethodItem<>(methodDef, codeAddress, instruction);
         }
     }
 }

--- a/baksmali/src/main/java/org/jf/baksmali/Adaptors/Format/PackedSwitchMethodItem.java
+++ b/baksmali/src/main/java/org/jf/baksmali/Adaptors/Format/PackedSwitchMethodItem.java
@@ -52,7 +52,7 @@ public class PackedSwitchMethodItem extends InstructionMethodItem<PackedSwitchPa
 
         int baseCodeAddress = methodDef.getPackedSwitchBaseAddress(codeAddress);
 
-        targets = new ArrayList<PackedSwitchTarget>();
+        targets = new ArrayList<>();
 
         boolean first = true;
         int firstKey = 0;

--- a/baksmali/src/main/java/org/jf/baksmali/Adaptors/Format/SparseSwitchMethodItem.java
+++ b/baksmali/src/main/java/org/jf/baksmali/Adaptors/Format/SparseSwitchMethodItem.java
@@ -51,7 +51,7 @@ public class SparseSwitchMethodItem extends InstructionMethodItem<SparseSwitchPa
 
         int baseCodeAddress = methodDef.getSparseSwitchBaseAddress(codeAddress);
 
-        targets = new ArrayList<SparseSwitchTarget>();
+        targets = new ArrayList<>();
         if (baseCodeAddress >= 0) {
             for (SwitchElement switchElement: instruction.getSwitchElements()) {
                 LabelMethodItem label = methodDef.getLabelCache().internLabel(

--- a/baksmali/src/main/java/org/jf/baksmali/Adaptors/MethodDefinition.java
+++ b/baksmali/src/main/java/org/jf/baksmali/Adaptors/MethodDefinition.java
@@ -375,7 +375,7 @@ public class MethodDefinition {
     }
 
     public List<MethodItem> getMethodItems() {
-        ArrayList<MethodItem> methodItems = new ArrayList<MethodItem>();
+        ArrayList<MethodItem> methodItems = new ArrayList<>();
 
         if ((classDef.options.registerInfo != 0) || (classDef.options.deodex && needsAnalyzed())) {
             addAnalyzedInstructionMethodItems(methodItems);
@@ -589,8 +589,8 @@ public class MethodDefinition {
     }
 
     private void setLabelSequentialNumbers() {
-        HashMap<String, Integer> nextLabelSequenceByType = new HashMap<String, Integer>();
-        ArrayList<LabelMethodItem> sortedLabels = new ArrayList<LabelMethodItem>(labelCache.getLabels());
+        HashMap<String, Integer> nextLabelSequenceByType = new HashMap<>();
+        ArrayList<LabelMethodItem> sortedLabels = new ArrayList<>(labelCache.getLabels());
 
         //sort the labels by their location in the method
         Collections.sort(sortedLabels);
@@ -614,7 +614,7 @@ public class MethodDefinition {
     }
 
     public static class LabelCache {
-        protected HashMap<LabelMethodItem, LabelMethodItem> labels = new HashMap<LabelMethodItem, LabelMethodItem>();
+        protected HashMap<LabelMethodItem, LabelMethodItem> labels = new HashMap<>();
 
         public LabelCache() {
         }

--- a/baksmali/src/main/java/org/jf/baksmali/baksmaliOptions.java
+++ b/baksmali/src/main/java/org/jf/baksmali/baksmaliOptions.java
@@ -60,8 +60,8 @@ public class baksmaliOptions {
     public List<String> bootClassPathEntries = Lists.newArrayList();
     public List<String> extraClassPathEntries = Lists.newArrayList();
 
-    public Map<String,String> resourceIdFileEntries = new HashMap<String,String>();
-    public Map<Integer,String> resourceIds = new HashMap<Integer,String>();
+    public Map<String,String> resourceIdFileEntries = new HashMap<>();
+    public Map<Integer,String> resourceIds = new HashMap<>();
 
     public boolean noParameterRegisters = false;
     public boolean useLocalsDirective = false;

--- a/dexlib2/src/main/java/org/jf/dexlib2/AccessFlags.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/AccessFlags.java
@@ -79,7 +79,7 @@ public enum AccessFlags {
     static {
         allFlags = AccessFlags.values();
 
-        accessFlagsByName = new HashMap<String, AccessFlags>();
+        accessFlagsByName = new HashMap<>();
         for (AccessFlags accessFlag : allFlags) {
             accessFlagsByName.put(accessFlag.accessFlagName, accessFlag);
         }

--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/CustomInlineMethodResolver.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/CustomInlineMethodResolver.java
@@ -56,7 +56,7 @@ public class CustomInlineMethodResolver extends InlineMethodResolver {
         this.classPath = classPath;
 
         StringReader reader = new StringReader(inlineTable);
-        List<String> lines = new ArrayList<String>();
+        List<String> lines = new ArrayList<>();
 
         BufferedReader br = new BufferedReader(reader);
 

--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/BaseDexBuffer.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/BaseDexBuffer.java
@@ -108,7 +108,7 @@ public class BaseDexBuffer {
 
     @Nonnull
     public BaseDexReader readerAt(int offset) {
-        return new BaseDexReader<BaseDexBuffer>(this, offset);
+        return new BaseDexReader<>(this, offset);
     }
 
     @Nonnull

--- a/dexlib2/src/main/java/org/jf/dexlib2/writer/DexWriter.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/writer/DexWriter.java
@@ -593,7 +593,7 @@ public abstract class DexWriter<
         encodedArraySectionOffset = writer.getPosition();
 
         HashMap<EncodedArrayKey<EncodedValue>, Integer> internedItems = Maps.newHashMap();
-        EncodedArrayKey<EncodedValue> key = new EncodedArrayKey<EncodedValue>();
+        EncodedArrayKey<EncodedValue> key = new EncodedArrayKey<>();
 
         for (ClassKey classKey: classSection.getSortedClasses()) {
             Collection <? extends EncodedValue> elements = classSection.getStaticInitializers(classKey);
@@ -606,7 +606,7 @@ public abstract class DexWriter<
                     int offset = writer.getPosition();
                     internedItems.put(key, offset);
                     classSection.setEncodedArrayOffset(classKey, offset);
-                    key = new EncodedArrayKey<EncodedValue>();
+                    key = new EncodedArrayKey<>();
 
                     numEncodedArrayItems++;
 
@@ -798,7 +798,7 @@ public abstract class DexWriter<
         ByteArrayOutputStream ehBuf = new ByteArrayOutputStream();
         debugSectionOffset = offsetWriter.getPosition();
         DebugWriter<StringKey, TypeKey> debugWriter =
-                new DebugWriter<StringKey, TypeKey>(stringSection, typeSection, offsetWriter);
+                new DebugWriter<>(stringSection, typeSection, offsetWriter);
 
         DexDataWriter codeWriter = new DexDataWriter(temp, 0);
 
@@ -844,7 +844,7 @@ public abstract class DexWriter<
                 int codeItemOffset = writeCodeItem(codeWriter, ehBuf, methodKey, tryBlocks, instructions, debugItemOffset);
 
                 if (codeItemOffset != -1) {
-                    codeOffsets.add(new CodeItemOffset<MethodKey>(methodKey, codeItemOffset));
+                    codeOffsets.add(new CodeItemOffset<>(methodKey, codeItemOffset));
                 }
             }
         }

--- a/smali/src/main/java/org/jf/smali/main.java
+++ b/smali/src/main/java/org/jf/smali/main.java
@@ -195,7 +195,7 @@ public class main {
         }
 
         try {
-            LinkedHashSet<File> filesToProcess = new LinkedHashSet<File>();
+            LinkedHashSet<File> filesToProcess = new LinkedHashSet<>();
 
             for (String arg : remainingArgs) {
                 File argFile = new File(arg);
@@ -224,7 +224,7 @@ public class main {
             final List<Future<Boolean>> tasks =
                     Lists.newArrayListWithCapacity(filesToProcess.size());
             final List<BuilderClassDef> classes = Collections.synchronizedList(
-                    new ArrayList<BuilderClassDef>(filesToProcess.size()));
+                    new ArrayList<>(filesToProcess.size()));
 
             final boolean finalVerboseErrors = verboseErrors;
             final boolean finalPrintTokens = printTokens;
@@ -264,7 +264,7 @@ public class main {
             final int MAX_FIELD_ADDED_DURING_DEX_CREATION = 9;
             final int MAX_DEX_ID = 65536;
             int dexNum = 0;
-            ArrayList<DexPool> pools = new ArrayList<DexPool>();
+            ArrayList<DexPool> pools = new ArrayList<>();
             DexPool dexPool = DexPool.makeDexPool(apiLevel);
             ClassPool clsPool = (ClassPool) dexPool.classSection;
             pools.add(dexPool);

--- a/smali/src/test/java/LexerTest.java
+++ b/smali/src/test/java/LexerTest.java
@@ -50,7 +50,7 @@ public class LexerTest {
     private static final HashMap<String, Integer> tokenTypesByName;
 
     static {
-        tokenTypesByName = new HashMap<String, Integer>();
+        tokenTypesByName = new HashMap<>();
 
         for (int i=0; i<smaliParser.tokenNames.length; i++) {
             tokenTypesByName.put(smaliParser.tokenNames[i], i);

--- a/util/src/main/java/org/jf/util/ArraySortedSet.java
+++ b/util/src/main/java/org/jf/util/ArraySortedSet.java
@@ -47,7 +47,7 @@ public class ArraySortedSet<T> implements SortedSet<T> {
     }
 
     public static <T> ArraySortedSet<T> of(@Nonnull Comparator<? super T> comparator, @Nonnull T[] arr) {
-        return new ArraySortedSet<T>(comparator, arr);
+        return new ArraySortedSet<>(comparator, arr);
     }
 
     @Override

--- a/util/src/main/java/org/jf/util/PathUtil.java
+++ b/util/src/main/java/org/jf/util/PathUtil.java
@@ -106,7 +106,7 @@ public class PathUtil {
     }
 
     private static ArrayList<String> getPathComponents(File file) {
-        ArrayList<String> path = new ArrayList<String>();
+        ArrayList<String> path = new ArrayList<>();
 
         while (file != null) {
             File parentFile = file.getParentFile();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2293 - “The diamond operator ("<>") should be used ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293

Please let me know if you have any questions.
Ayman Abdelghany.