### PR TITLE
[squid:S1609] @FunctionalInterface annotation should be used to flag Single Abstract Method interfaces

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/ClassProto.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/ClassProto.java
@@ -661,6 +661,7 @@ public class ClassProto implements TypeProto {
         final static int sizeof_uint16_t = 2;
         final static int sizeof_uint8_t = 1;
 
+        @FunctionalInterface
         interface IFieldGapCreator {
             FieldGap create(int offset, int size);
         }

--- a/dexlib2/src/main/java/org/jf/dexlib2/builder/MutableMethodImplementation.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/builder/MutableMethodImplementation.java
@@ -123,6 +123,7 @@ public class MutableMethodImplementation implements MethodImplementation {
         }
     }
 
+    @FunctionalInterface
     private interface Task {
         void perform();
     }

--- a/dexlib2/src/main/java/org/jf/dexlib2/iface/Annotatable.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/iface/Annotatable.java
@@ -37,6 +37,7 @@ import java.util.Set;
 /**
  * This class represents an object that can have Annotations applied to it
  */
+@FunctionalInterface
 public interface Annotatable {
     /**
      * Gets a set of the annotations that are applied to this object.

--- a/dexlib2/src/main/java/org/jf/dexlib2/iface/DexFile.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/iface/DexFile.java
@@ -37,6 +37,7 @@ import java.util.Set;
 /**
  * This class is a high level representation of a dex file - essentially a set of class definitions.
  */
+@FunctionalInterface
 public interface DexFile {
     /**
      * Get a set of the classes defined in this dex file.

--- a/dexlib2/src/main/java/org/jf/dexlib2/writer/io/DeferredOutputStreamFactory.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/writer/io/DeferredOutputStreamFactory.java
@@ -2,6 +2,7 @@ package org.jf.dexlib2.writer.io;
 
 import java.io.IOException;
 
+@FunctionalInterface
 public interface DeferredOutputStreamFactory {
     DeferredOutputStream makeDeferredOutputStream() throws IOException;
 }

--- a/smali/src/main/java/org/jf/smali/LexerErrorInterface.java
+++ b/smali/src/main/java/org/jf/smali/LexerErrorInterface.java
@@ -32,6 +32,7 @@ import org.antlr.runtime.CharStream;
 import org.antlr.runtime.Lexer;
 import org.antlr.runtime.RecognizerSharedState;
 
+@FunctionalInterface
 public interface LexerErrorInterface {
     public int getNumberOfSyntaxErrors();
 

--- a/smali/src/main/java/org/jf/smali/WithRegister.java
+++ b/smali/src/main/java/org/jf/smali/WithRegister.java
@@ -31,6 +31,7 @@
 
 package org.jf.smali;
 
+@FunctionalInterface
 public interface WithRegister {
     int getRegister();
 }

--- a/smaliex/src/main/java/com/android/ddmlib/AndroidDebugBridge.java
+++ b/smaliex/src/main/java/com/android/ddmlib/AndroidDebugBridge.java
@@ -90,6 +90,7 @@ public final class AndroidDebugBridge {
      * Classes which implement this interface provide a method that deals
      * with {@link AndroidDebugBridge} changes.
      */
+    @FunctionalInterface
     public interface IDebugBridgeChangeListener {
         /**
          * Sent when a new {@link AndroidDebugBridge} is connected.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1609 - “ @FunctionalInterface annotation should be used to flag Single Abstract Method interfaces ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1609

Please let me know if you have any questions.
Ayman Abdelghany.
