### PR TITLE
[squid:S1873] "static final" arrays should be "private"

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/RegisterType.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/RegisterType.java
@@ -128,7 +128,7 @@ public class RegisterType {
     // incomming code path. There is no register type that can hold either an Integer or a Reference.
     public static final byte CONFLICTED = 19;
 
-    public static final String[] CATEGORY_NAMES = new String[] {
+    private static final String[] CATEGORY_NAMES = new String[] {
             "Unknown",
             "Uninit",
             "Null",

--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/raw/HeaderItem.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/raw/HeaderItem.java
@@ -47,7 +47,7 @@ public class HeaderItem {
      *
      * They are: "dex\n035\0" and "dex\n037\0".
      */
-    public static final byte[][] MAGIC_VALUES= new byte[][] {
+    private static final byte[][] MAGIC_VALUES= new byte[][] {
             new byte[]{0x64, 0x65, 0x78, 0x0a, 0x30, 0x33, 0x35, 0x00},
             new byte[]{0x64, 0x65, 0x78, 0x0a, 0x30, 0x33, 0x37, 0x00}};
 

--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/raw/OdexHeaderItem.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/raw/OdexHeaderItem.java
@@ -36,7 +36,7 @@ import org.jf.dexlib2.dexbacked.BaseDexBuffer;
 public class OdexHeaderItem {
     public static final int ITEM_SIZE = 40;
 
-    public static final byte[][] MAGIC_VALUES= new byte[][] {
+    private static final byte[][] MAGIC_VALUES= new byte[][] {
             new byte[] {0x64, 0x65, 0x79, 0x0A, 0x30, 0x33, 0x35, 0x00}, // "dey\n035\0"
             new byte[] {0x64, 0x65, 0x79, 0x0A, 0x30, 0x33, 0x36, 0x00}  // "dey\n036\0"
     };


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1873 - “ "static final" arrays should be "private" ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1873

Please let me know if you have any questions.
Ayman Abdelghany.
