### PR TITLE
[squid:S1118] Utility classes should not have public constructors

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/reflection/util/ReflectionUtils.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/reflection/util/ReflectionUtils.java
@@ -32,6 +32,9 @@
 package org.jf.dexlib2.analysis.reflection.util;
 
 public class ReflectionUtils {
+    private ReflectionUtils() {
+    }
+
     public static String javaToDexName(String javaName) {
         javaName = javaName.replace('.', '/');
         if (javaName.length() > 1 && javaName.charAt(javaName.length()-1) != ';') {

--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/util/TypeProtoUtils.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/util/TypeProtoUtils.java
@@ -40,6 +40,9 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 public class TypeProtoUtils {
+    private TypeProtoUtils() {
+    }
+
     /**
      * Get the chain of superclasses of the given class. The first element will be the immediate superclass followed by
      * it's superclass, etc. up to java.lang.Object.

--- a/dexlib2/src/main/java/org/jf/dexlib2/immutable/util/ParamUtil.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/immutable/util/ParamUtil.java
@@ -37,6 +37,9 @@ import javax.annotation.Nonnull;
 import java.util.Iterator;
 
 public class ParamUtil {
+    private ParamUtil() {
+    }
+
     private static int findTypeEnd(@Nonnull String str, int index) {
         char c = str.charAt(index);
         switch (c) {

--- a/dexlib2/src/main/java/org/jf/dexlib2/rewriter/RewriterUtils.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/rewriter/RewriterUtils.java
@@ -39,6 +39,9 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class RewriterUtils {
+    private RewriterUtils() {
+    }
+
     @Nullable
     public static <T> T rewriteNullable(@Nonnull Rewriter<T> rewriter, @Nullable T value) {
         return value==null?null:rewriter.rewrite(value);

--- a/dexlib2/src/test/java/org/jf/dexlib2/analysis/TestUtils.java
+++ b/dexlib2/src/test/java/org/jf/dexlib2/analysis/TestUtils.java
@@ -40,6 +40,9 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class TestUtils {
+    private TestUtils() {
+    }
+
     public static ClassDef makeClassDef(@Nonnull String classType, @Nullable String superType, String... interfaces) {
         return new ImmutableClassDef(classType, 0, superType, ImmutableSet.copyOf(interfaces),
                 null, null, null, null, null, null);

--- a/smaliex/src/main/java/org/rh/smaliex/AdbUtil.java
+++ b/smaliex/src/main/java/org/rh/smaliex/AdbUtil.java
@@ -34,6 +34,9 @@ import com.android.ddmlib.SyncService.SyncException;
 
 public class AdbUtil {
 
+    private AdbUtil() {
+    }
+
     public static abstract class DeviceListener implements AndroidDebugBridge.IDeviceChangeListener {
         //public void deviceChanged(Device device, int changeMask) {
         //}

--- a/smaliex/src/main/java/org/rh/smaliex/DexUtil.java
+++ b/smaliex/src/main/java/org/rh/smaliex/DexUtil.java
@@ -56,6 +56,9 @@ public class DexUtil {
     private static final ConcurrentHashMap<Integer, SoftReference<Opcodes>> opCodesCache =
             new ConcurrentHashMap<>();
 
+    private DexUtil() {
+    }
+
     public static Opcodes getOpcodes(int apiLevel) {
         Opcodes opcodes = getCache(opCodesCache, apiLevel);
         if (opcodes == null) {

--- a/smaliex/src/main/java/org/rh/smaliex/MiscUtil.java
+++ b/smaliex/src/main/java/org/rh/smaliex/MiscUtil.java
@@ -23,6 +23,9 @@ import java.io.RandomAccessFile;
 
 public class MiscUtil {
 
+    private MiscUtil() {
+    }
+
     public static File changeExt(File f, String targetExt) {
         String outPath = f.getAbsolutePath();
         if (!outPath.endsWith(targetExt)) {

--- a/smaliex/src/main/java/org/rh/smaliex/OatUtil.java
+++ b/smaliex/src/main/java/org/rh/smaliex/OatUtil.java
@@ -41,6 +41,9 @@ import org.rh.smaliex.reader.Oat;
 
 public class OatUtil {
 
+    private OatUtil() {
+    }
+
     public static Opcodes getOpcodes(Oat oat) {
         int key = oat.getArtVersion() << Opcodes.OFFSET_OAT_VERSION | oat.guessApiLevel();
         return DexUtil.getOpcodes(key);

--- a/util/src/main/java/org/jf/util/BitSetUtils.java
+++ b/util/src/main/java/org/jf/util/BitSetUtils.java
@@ -34,6 +34,9 @@ package org.jf.util;
 import java.util.BitSet;
 
 public class BitSetUtils {
+    private BitSetUtils() {
+    }
+
     public static BitSet bitSetOfIndexes(int... indexes) {
         BitSet bitSet = new BitSet();
         for (int index: indexes) {

--- a/util/src/main/java/org/jf/util/CharSequenceUtils.java
+++ b/util/src/main/java/org/jf/util/CharSequenceUtils.java
@@ -40,6 +40,9 @@ import java.util.List;
 public class CharSequenceUtils {
     private static final Function<Object, String> TO_STRING = Functions.toStringFunction();
 
+    private CharSequenceUtils() {
+    }
+
     public static int listHashCode(List<? extends CharSequence> list) {
         return Lists.transform(list, TO_STRING).hashCode();
     }

--- a/util/src/main/java/org/jf/util/CollectionUtils.java
+++ b/util/src/main/java/org/jf/util/CollectionUtils.java
@@ -40,6 +40,9 @@ import javax.annotation.Nonnull;
 import java.util.*;
 
 public class CollectionUtils {
+    private CollectionUtils() {
+    }
+
     public static <T> int listHashCode(@Nonnull Iterable<T> iterable) {
         int hashCode = 1;
         for (T item: iterable) {

--- a/util/src/main/java/org/jf/util/ConsoleUtil.java
+++ b/util/src/main/java/org/jf/util/ConsoleUtil.java
@@ -33,6 +33,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class ConsoleUtil {
+    private ConsoleUtil() {
+    }
+
     /**
      * Attempt to find the width of the console. If it can't get the width, return a default of 80
      * @return The current console width

--- a/util/src/main/java/org/jf/util/ImmutableUtils.java
+++ b/util/src/main/java/org/jf/util/ImmutableUtils.java
@@ -39,6 +39,9 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class ImmutableUtils {
+    private ImmutableUtils() {
+    }
+
     @Nonnull public static <T> ImmutableList<T> nullToEmptyList(@Nullable ImmutableList<T> list) {
         if (list == null) {
             return ImmutableList.of();

--- a/util/src/main/java/org/jf/util/NumberUtils.java
+++ b/util/src/main/java/org/jf/util/NumberUtils.java
@@ -46,6 +46,9 @@ public class NumberUtils {
 
     private static final DecimalFormat format = new DecimalFormat("0.####################E0");
 
+    private NumberUtils() {
+    }
+
     public static boolean isLikelyFloat(int value) {
         // Check for some common named float values
         // We don't check for Float.MIN_VALUE, which has an integer representation of 1

--- a/util/src/main/java/org/jf/util/StringUtils.java
+++ b/util/src/main/java/org/jf/util/StringUtils.java
@@ -35,6 +35,9 @@ import java.io.IOException;
 import java.io.Writer;
 
 public class StringUtils {
+    private StringUtils() {
+    }
+
     public static void writeEscapedChar(Writer writer, char c) throws IOException {
         if ((c >= ' ') && (c < 0x7f)) {
             if ((c == '\'') || (c == '\"') || (c == '\\')) {

--- a/util/src/main/java/org/jf/util/TextUtils.java
+++ b/util/src/main/java/org/jf/util/TextUtils.java
@@ -38,6 +38,9 @@ import java.util.regex.Pattern;
 public class TextUtils {
     private static String newline = System.getProperty("line.separator");
 
+    private TextUtils() {
+    }
+
     @Nonnull
     public static String normalizeNewlines(@Nonnull String source) {
         return normalizeNewlines(source, newline);

--- a/util/src/main/java/org/jf/util/Utf8Utils.java
+++ b/util/src/main/java/org/jf/util/Utf8Utils.java
@@ -31,6 +31,9 @@ import javax.annotation.Nullable;
  * Constants of type <code>CONSTANT_Utf8_info</code>.
  */
 public final class Utf8Utils {
+    private Utf8Utils() {
+    }
+
     /**
      * Converts a string into its Java-style UTF-8 form. Java-style UTF-8
      * differs from normal UTF-8 in the handling of character '\0' and


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Ayman Abdelghany.
