### PR TITLE
[squid:S1155] Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/baksmali/src/main/java/org/jf/baksmali/Adaptors/ClassDefinition.java
+++ b/baksmali/src/main/java/org/jf/baksmali/Adaptors/ClassDefinition.java
@@ -148,7 +148,7 @@ public class ClassDefinition {
     private void writeInterfaces(IndentingWriter writer) throws IOException {
         List<String> interfaces = classDef.getInterfaces();
 
-        if (interfaces.size() != 0) {
+        if (!interfaces.isEmpty()) {
             writer.write('\n');
             writer.write("# interfaces\n");
             for (String interfaceName: interfaces) {
@@ -161,7 +161,7 @@ public class ClassDefinition {
 
     private void writeAnnotations(IndentingWriter writer) throws IOException {
         Collection<? extends Annotation> classAnnotations = classDef.getAnnotations();
-        if (classAnnotations.size() != 0) {
+        if (!classAnnotations.isEmpty()) {
             writer.write("\n\n");
             writer.write("# annotations\n");
 

--- a/baksmali/src/main/java/org/jf/baksmali/Adaptors/EncodedValue/ArrayEncodedValueAdaptor.java
+++ b/baksmali/src/main/java/org/jf/baksmali/Adaptors/EncodedValue/ArrayEncodedValueAdaptor.java
@@ -43,7 +43,7 @@ public class ArrayEncodedValueAdaptor {
                                @Nullable String containingClass) throws IOException {
         writer.write('{');
         Collection<? extends EncodedValue> values = arrayEncodedValue.getValue();
-        if (values.size() == 0) {
+        if (values.isEmpty()) {
             writer.write('}');
             return;
         }

--- a/baksmali/src/main/java/org/jf/baksmali/Adaptors/FieldDefinition.java
+++ b/baksmali/src/main/java/org/jf/baksmali/Adaptors/FieldDefinition.java
@@ -78,7 +78,7 @@ public class FieldDefinition {
         writer.write('\n');
 
         Collection<? extends Annotation> annotations = field.getAnnotations();
-        if (annotations.size() > 0) {
+        if (!annotations.isEmpty()) {
             writer.indent(4);
 
             String containingClass = null;

--- a/baksmali/src/main/java/org/jf/baksmali/Adaptors/MethodDefinition.java
+++ b/baksmali/src/main/java/org/jf/baksmali/Adaptors/MethodDefinition.java
@@ -331,7 +331,7 @@ public class MethodDefinition {
             String parameterType = parameter.getType();
             String parameterName = parameter.getName();
             Collection<? extends Annotation> annotations = parameter.getAnnotations();
-            if ((options.outputDebugInfo && parameterName != null) || annotations.size() != 0) {
+            if ((options.outputDebugInfo && parameterName != null) || !annotations.isEmpty()) {
                 writer.write(".param p");
                 writer.printSignedIntAsDec(registerNumber);
 
@@ -342,7 +342,7 @@ public class MethodDefinition {
                 writer.write("    # ");
                 writer.write(parameterType);
                 writer.write("\n");
-                if (annotations.size() > 0) {
+                if (!annotations.isEmpty()) {
                     writer.indent(4);
 
                     String containingClass = null;
@@ -536,7 +536,7 @@ public class MethodDefinition {
 
     private void addTries(List<MethodItem> methodItems) {
         List<? extends TryBlock<? extends ExceptionHandler>> tryBlocks = methodImpl.getTryBlocks();
-        if (tryBlocks.size() == 0) {
+        if (tryBlocks.isEmpty()) {
             return;
         }
 

--- a/dexlib2/src/main/java/org/jf/dexlib2/builder/MutableMethodImplementation.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/builder/MutableMethodImplementation.java
@@ -935,7 +935,7 @@ public class MutableMethodImplementation implements MethodImplementation {
                                                                      @Nonnull int[] codeAddressToIndex,
                                                                      @Nonnull PackedSwitchPayload instruction) {
         List<? extends SwitchElement> switchElements = instruction.getSwitchElements();
-        if (switchElements.size() == 0) {
+        if (switchElements.isEmpty()) {
             return new BuilderPackedSwitchPayload(0, null);
         }
 
@@ -960,7 +960,7 @@ public class MutableMethodImplementation implements MethodImplementation {
                                                                      @Nonnull int[] codeAddressToIndex,
                                                                      @Nonnull SparseSwitchPayload instruction) {
         List<? extends SwitchElement> switchElements = instruction.getSwitchElements();
-        if (switchElements.size() == 0) {
+        if (switchElements.isEmpty()) {
             return new BuilderSparseSwitchPayload(null);
         }
 

--- a/util/src/main/java/org/jf/util/ImmutableConverter.java
+++ b/util/src/main/java/org/jf/util/ImmutableConverter.java
@@ -144,7 +144,7 @@ public abstract class ImmutableConverter<ImmutableItem, Item> {
     @Nonnull
     public SortedSet<ImmutableItem> toSortedSet(@Nonnull Comparator<? super ImmutableItem> comparator,
                                                 @Nullable final SortedSet<? extends Item> sortedSet) {
-        if (sortedSet == null || sortedSet.size() == 0) {
+        if (sortedSet == null || sortedSet.isEmpty()) {
             return ImmutableSortedSet.of();
         }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155

Please let me know if you have any questions.
Ayman Abdelghany.