### PR TITLE
[squid:S1161] "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one

### DIFF
--- a/baksmali/src/main/java/org/jf/baksmali/Adaptors/MethodItem.java
+++ b/baksmali/src/main/java/org/jf/baksmali/Adaptors/MethodItem.java
@@ -46,6 +46,7 @@ public abstract class MethodItem implements Comparable<MethodItem> {
     //return an arbitrary double that determines how this item will be sorted with others at the same address
     public abstract double getSortOrder();
 
+    @Override
     public int compareTo(MethodItem methodItem) {
         int result = ((Integer) codeAddress).compareTo(methodItem.codeAddress);
 

--- a/baksmali/src/main/java/org/jf/baksmali/baksmali.java
+++ b/baksmali/src/main/java/org/jf/baksmali/baksmali.java
@@ -88,6 +88,7 @@ public class baksmali {
                     this.prefix = prefix;
                 }
 
+                @Override
                 public void startElement(String uri, String localName,
                         String qName, Attributes attr) throws SAXException {
                     if (qName.equals("public")) {

--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/AnalyzedInstruction.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/AnalyzedInstruction.java
@@ -449,6 +449,7 @@ public class AnalyzedInstruction implements Comparable<AnalyzedInstruction> {
         return preRegisterMap[registerNumber];
     }
 
+    @Override
     public int compareTo(@Nonnull AnalyzedInstruction analyzedInstruction) {
         if (instructionIndex < analyzedInstruction.instructionIndex) {
             return -1;

--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/util/AnnotationsDirectory.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/util/AnnotationsDirectory.java
@@ -155,6 +155,7 @@ public abstract class AnnotationsDirectory {
             this.directoryOffset = directoryOffset;
         }
 
+        @Override
         public int getFieldAnnotationCount() {
             return dexFile.readSmallUint(directoryOffset + FIELD_COUNT_OFFSET);
         }
@@ -167,11 +168,13 @@ public abstract class AnnotationsDirectory {
             return dexFile.readSmallUint(directoryOffset + PARAMETER_COUNT_OFFSET);
         }
 
+        @Override
         @Nonnull
         public Set<? extends DexBackedAnnotation> getClassAnnotations() {
             return getAnnotations(dexFile, dexFile.readSmallUint(directoryOffset));
         }
 
+        @Override
         @Nonnull
         public AnnotationIterator getFieldAnnotationIterator() {
             int fieldAnnotationCount = getFieldAnnotationCount();
@@ -181,6 +184,7 @@ public abstract class AnnotationsDirectory {
             return new AnnotationIteratorImpl(directoryOffset + ANNOTATIONS_START_OFFSET, fieldAnnotationCount);
         }
 
+        @Override
         @Nonnull
         public AnnotationIterator getMethodAnnotationIterator() {
             int methodCount = getMethodAnnotationCount();
@@ -193,6 +197,7 @@ public abstract class AnnotationsDirectory {
             return new AnnotationIteratorImpl(methodAnnotationsOffset, methodCount);
         }
 
+        @Override
         @Nonnull
         public AnnotationIterator getParameterAnnotationIterator() {
             int parameterAnnotationCount = getParameterAnnotationCount();
@@ -220,6 +225,7 @@ public abstract class AnnotationsDirectory {
                 this.currentIndex = 0;
             }
 
+            @Override
             public int seekTo(int itemIndex) {
                 while (currentItemIndex < itemIndex && (currentIndex+1) < size) {
                     currentIndex++;
@@ -232,6 +238,7 @@ public abstract class AnnotationsDirectory {
                 return 0;
             }
 
+            @Override
             public void reset() {
                 this.currentItemIndex = dexFile.readSmallUint(startOffset);
                 this.currentIndex = 0;

--- a/dexlib2/src/main/java/org/jf/dexlib2/writer/builder/BuilderProtoPool.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/writer/builder/BuilderProtoPool.java
@@ -120,10 +120,12 @@ class BuilderProtoPool
             this.returnType = returnType;
         }
 
+        @Override
         @Nonnull public List<? extends CharSequence> getParameterTypes() {
             return parameters;
         }
 
+        @Override
         @Nonnull public String getReturnType() {
             return returnType;
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1161 - “ "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1161

Please let me know if you have any questions.
Ayman Abdelghany.