### PR TITLE
[squid:S1149] Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/util/src/main/java/org/jf/util/ConsoleUtil.java
+++ b/util/src/main/java/org/jf/util/ConsoleUtil.java
@@ -82,7 +82,7 @@ public class ConsoleUtil {
     }
 
     private static String attemptCommand(String[] command) {
-        StringBuffer buffer = null;
+        StringBuilder buffer = null;
 
         try {
 
@@ -93,7 +93,7 @@ public class ConsoleUtil {
 
             while ((line = reader.readLine()) != null) {
                 if (buffer == null) {
-                    buffer = new StringBuffer();
+                    buffer = new StringBuilder();
                 }
 
                 buffer.append(line);

--- a/util/src/main/java/org/jf/util/Hex.java
+++ b/util/src/main/java/org/jf/util/Hex.java
@@ -277,7 +277,7 @@ public final class Hex {
             return "";
         }
 
-        StringBuffer sb = new StringBuffer(length * 4 + 6);
+        StringBuilder sb = new StringBuilder(length * 4 + 6);
         boolean bol = true;
         int col = 0;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149

Please let me know if you have any questions.
Ayman Abdelghany.
