### PR TITLE
[squid:S1319] Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList"

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/ClassProto.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/ClassProto.java
@@ -442,7 +442,7 @@ public class ClassProto implements TypeProto {
                 return;
             }
             System.out.println("## Field offset of " + classProto.type);
-            ArrayList<ClassProto> classHierarchy = new ArrayList<>();
+            List<ClassProto> classHierarchy = new ArrayList<>();
             ClassProto cp = classProto;
             for (String superclassType = cp.getSuperclass(); superclassType != null;
                     superclassType = cp.getSuperclass()) {
@@ -947,7 +947,7 @@ public class ClassProto implements TypeProto {
             // the same field offsets (which is needed for deodexing).
             // See dalvik/vm/oo/Class.c computeFieldOffsets()
 
-            ArrayList<Field> fields = Lists.newArrayList(
+            List<Field> fields = Lists.newArrayList(
                     classProto.getClassDef().getInstanceFields());
             Collections.sort(fields);
             final int fieldCount = fields.size();

--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/DumpFields.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/DumpFields.java
@@ -47,6 +47,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 public class DumpFields {
     private static final Options options;
@@ -70,7 +71,7 @@ public class DumpFields {
         String[] remainingArgs = commandLine.getArgs();
 
         Option[] parsedOptions = commandLine.getOptions();
-        ArrayList<String> bootClassPathDirs = Lists.newArrayList();
+        List<String> bootClassPathDirs = Lists.newArrayList();
         String outFile = "fields.txt";
         int apiLevel = 15;
         boolean experimental = false;

--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/DumpVtables.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/DumpVtables.java
@@ -68,7 +68,7 @@ public class DumpVtables {
         String[] remainingArgs = commandLine.getArgs();
 
         Option[] parsedOptions = commandLine.getOptions();
-        ArrayList<String> bootClassPathDirs = Lists.newArrayList();
+        List<String> bootClassPathDirs = Lists.newArrayList();
         String outFile = "vtables.txt";
         int apiLevel = 15;
         boolean experimental = false;

--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/MethodAnalyzer.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/MethodAnalyzer.java
@@ -2023,7 +2023,7 @@ public class MethodAnalyzer {
 
     @Nonnull
     private RegisterType getLastRegisterType(int reg) {
-        ArrayList<TypeScope> scopes = localTypes.get(reg);
+        List<TypeScope> scopes = localTypes.get(reg);
         if (scopes != null) {
             return scopes.get(scopes.size() - 1).type;
         }

--- a/dexlib2/src/main/java/org/jf/dexlib2/writer/pool/ClassPool.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/writer/pool/ClassPool.java
@@ -97,7 +97,7 @@ public class ClassPool implements ClassSection<CharSequence, CharSequence,
         typeListPool.intern(poolClassDef.getInterfaces());
         stringPool.internNullable(poolClassDef.getSourceFile());
 
-        HashSet<String> fields = new HashSet<String>();
+        Set<String> fields = new HashSet<String>();
         for (Field field: poolClassDef.getFields()) {
             String fieldDescriptor = ReferenceUtil.getShortFieldDescriptor(field);
             if (!fields.add(fieldDescriptor)) {
@@ -114,7 +114,7 @@ public class ClassPool implements ClassSection<CharSequence, CharSequence,
             annotationSetPool.intern(field.getAnnotations());
         }
 
-        HashSet<String> methods = new HashSet<String>();
+        Set<String> methods = new HashSet<String>();
         for (PoolMethod method: poolClassDef.getMethods()) {
             String methodDescriptor = ReferenceUtil.getMethodDescriptor(method, true);
             if (!methods.add(methodDescriptor)) {

--- a/smali/src/main/java/org/jf/smali/main.java
+++ b/smali/src/main/java/org/jf/smali/main.java
@@ -195,7 +195,7 @@ public class main {
         }
 
         try {
-            LinkedHashSet<File> filesToProcess = new LinkedHashSet<File>();
+            Set<File> filesToProcess = new LinkedHashSet<File>();
 
             for (String arg : remainingArgs) {
                 File argFile = new File(arg);
@@ -264,7 +264,7 @@ public class main {
             final int MAX_FIELD_ADDED_DURING_DEX_CREATION = 9;
             final int MAX_DEX_ID = 65536;
             int dexNum = 0;
-            ArrayList<DexPool> pools = new ArrayList<DexPool>();
+            List<DexPool> pools = new ArrayList<DexPool>();
             DexPool dexPool = DexPool.makeDexPool(apiLevel);
             ClassPool clsPool = (ClassPool) dexPool.classSection;
             pools.add(dexPool);

--- a/util/src/main/java/org/jf/util/PathUtil.java
+++ b/util/src/main/java/org/jf/util/PathUtil.java
@@ -31,6 +31,7 @@ package org.jf.util;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 public class PathUtil {
     private PathUtil() {
@@ -55,8 +56,8 @@ public class PathUtil {
     }
 
     static String getRelativeFileInternal(File canonicalBaseFile, File canonicalFileToRelativize) {
-        ArrayList<String> basePath = getPathComponents(canonicalBaseFile);
-        ArrayList<String> pathToRelativize = getPathComponents(canonicalFileToRelativize);
+        List<String> basePath = getPathComponents(canonicalBaseFile);
+        List<String> pathToRelativize = getPathComponents(canonicalFileToRelativize);
 
         //if the roots aren't the same (i.e. different drives on a windows machine), we can't construct a relative
         //path from one to the other, so just return the canonical file


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S00115 - “Constant names should comply with a naming convention”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S00115

Please let me know if you have any questions.
Ayman Abdelghany.
